### PR TITLE
세션 스토리지에 토큰이 존재하는지 여부 검사

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ export default {
     } else {
       sessionStorage.setItem("mainZaboSeen", true);
     }
-    if (sessionStorage.getItem("token").split(" ")[0] == "ZABO") {
+    if (sessionStorage.getItem("token") && sessionStorage.getItem("token").split(" ")[0] == "ZABO") {
       this.$store.dispatch("login", sessionStorage.getItem("token").slice(5));
       axios
         .get("api/users/myInfo", {


### PR DESCRIPTION
`sessionStorage`에 token key가 없으면 에러가 납니다. 에러를 줄여봅시다.